### PR TITLE
Add llama-cli summary feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
   - A main file `main_project.md` is created from a customizable template.
   - Automatically added to `~/.zd/projects/projects.md` (a master index).
   - Quickly open any project from an interactive prompt.
+- **Llama Summaries**:
+  - Use `llama-cli` to generate a summary of recent daily notes.
+  - Trigger with `<leader>zs` for the last day or call `:call <SID>SummarizeRecentDays(n)` for `n` days.
+  - `:call <SID>SummarizeRecentWeeks(n)` summarizes `n` weeks (7×n days).
 
 - **Templating System**:
   - Store your own markdown templates in `~/.zd/templates/` (e.g. `daily.md`, `weekly.md`, etc.).
@@ -50,6 +54,7 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
 1. **Prerequisites**:
    - You need a running Vim or Neovim environment.
    - This plugin is pure Vimscript; no external dependencies required.
+   - Install `llama-cli` if you want to use the summary feature.
 
 2. **Plugin File**:
    - Save the plugin script as `vim-zk.vim` in your local plugin directory:
@@ -91,6 +96,7 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
 | `<leader>tO` | **Open Done TODOS**: Quickly open `~/.zd/todos/done_todos.md`.                               |
 | `<leader>zp` | **Open/Prompt for Project**: Creates or opens a project’s `main_project.md`.                 |
 | `<leader>zP` | **Open Projects Index**: Opens the master `projects.md` listing all created projects.        |
+| `<leader>zs` | **Summarize Dailies**: Run `llama-cli` on the last day (or use `:call <SID>SummarizeRecentDays(n)` for more). |
 
 ### Example Workflows
 


### PR DESCRIPTION
## Summary
- add `g:zd_llama_repo` configuration for llama model
- implement `SummarizeRecentDays` and `SummarizeRecentWeeks` helpers
- map `<leader>zs` to summarize last day by default
- document llama summary support and mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a4893f748326a2d3e1a491b0c435