### PR TITLE
Add llama-cli summary feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
   - A main file `main_project.md` is created from a customizable template.
   - Automatically added to `~/.zd/projects/projects.md` (a master index).
   - Quickly open any project from an interactive prompt.
+  - Daily notes show all projects grouped by area for quick access.
+- **Llama Summaries**:
+  - Use `llama-cli` to generate a summary of recent daily notes.
+  - Trigger with `<leader>zs` for the last day or call `:call <SID>SummarizeRecentDays(n)` for `n` days.
+  - `:call <SID>SummarizeRecentWeeks(n)` summarizes `n` weeks (7×n days).
 
 - **Templating System**:
   - Store your own markdown templates in `~/.zd/templates/` (e.g. `daily.md`, `weekly.md`, etc.).
@@ -50,6 +55,7 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
 1. **Prerequisites**:
    - You need a running Vim or Neovim environment.
    - This plugin is pure Vimscript; no external dependencies required.
+   - Install `llama-cli` if you want to use the summary feature.
 
 2. **Plugin File**:
    - Save the plugin script as `vim-zk.vim` in your local plugin directory:
@@ -91,6 +97,7 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
 | `<leader>tO` | **Open Done TODOS**: Quickly open `~/.zd/todos/done_todos.md`.                               |
 | `<leader>zp` | **Open/Prompt for Project**: Creates or opens a project’s `main_project.md`.                 |
 | `<leader>zP` | **Open Projects Index**: Opens the master `projects.md` listing all created projects.        |
+| `<leader>zs` | **Summarize Dailies**: Run `llama-cli` on the last day (or use `:call <SID>SummarizeRecentDays(n)` for more). |
 
 ### Example Workflows
 
@@ -149,6 +156,9 @@ Each note type can have a markdown template in `~/.zd/templates/<type>.md`. For 
 ---
 
 ## {{READABLE_DATE}}
+
+#### Projects by Area
+{{PROJECTS_BY_AREA}}
 
 ### Morning Thoughts
 -

--- a/templates/daily.md
+++ b/templates/daily.md
@@ -15,6 +15,7 @@
 
 #### Projects
 -
+{{PROJECTS_BY_AREA}}
 
 ### Today
 

--- a/vim-zk.vim
+++ b/vim-zk.vim
@@ -39,6 +39,9 @@ let g:zd_done_todos   = g:zd_dir_todos . '/done_todos.md'
 let g:zd_projects_index = g:zd_dir_projects . '/projects.md'
 let g:zd_areas_index = g:zd_dir_areas . '/areas.md'
 
+" Llama model repo for summaries
+let g:zd_llama_repo = 'bartowski/Llama-3.2-3B-Instruct-GGUF:Q8_0'
+
 " Create top-level directories if they don't exist
 call mkdir(g:zd_dir_daily, 'p')
 call mkdir(g:zd_dir_weekly, 'p')
@@ -92,6 +95,46 @@ endfunction
 
 
 " =============================================================================
+"              COLLECT PROJECTS ORGANIZED BY AREA FOR DAILY NOTES
+" =============================================================================
+function! s:ProjectsByAreaLines() abort
+  let l:out = []
+  if !isdirectory(g:zd_dir_areas)
+    return l:out
+  endif
+  let l:dirs = sort(filter(split(globpath(g:zd_dir_areas, '*', 1, 1), '\n'), 'isdirectory(v:val)'))
+  for l:dir in l:dirs
+    let l:area_name = fnamemodify(l:dir, ':t')
+    let l:file = l:dir . '/main_area.md'
+    if !filereadable(l:file)
+      continue
+    endif
+    let l:lines = readfile(l:file)
+    let l:start = index(l:lines, '## Projects')
+    if l:start < 0
+      continue
+    endif
+    let l:list = []
+    for l:i in range(l:start + 1, len(l:lines) - 1)
+      let l:ln = l:lines[l:i]
+      if l:ln =~# '^##'
+        break
+      endif
+      if l:ln =~# '^-'
+        call add(l:list, '  ' . l:ln)
+      endif
+    endfor
+    if !empty(l:list)
+      call add(l:out, '##### ' . l:area_name)
+      call extend(l:out, l:list)
+      call add(l:out, '')
+    endif
+  endfor
+  return l:out
+endfunction
+
+
+" =============================================================================
 "                    DAILY NOTE (<leader>zd) with READABLE_DATE
 " =============================================================================
 
@@ -122,6 +165,7 @@ function! s:OpenDailyNote(...) abort
     let l:month_str = strftime('%y%m', (l:t > 0 ? l:t : localtime()))
     let l:year_str  = strftime('%y',   (l:t > 0 ? l:t : localtime()))
 
+    let l:proj_lines = s:ProjectsByAreaLines()
     let l:replacements = {
     \ 'TODAY': l:today_str,
     \ 'PREV_DAY': l:prev_str,
@@ -134,6 +178,7 @@ function! s:OpenDailyNote(...) abort
     \ 'PATH_WEEKLY': g:zd_dir_weekly,
     \ 'PATH_MONTHLY': g:zd_dir_monthly,
     \ 'PATH_YEARLY': g:zd_dir_yearly,
+    \ 'PROJECTS_BY_AREA': join(l:proj_lines, "\n"),
     \}
 
     let l:lines = s:LoadTemplateAndReplace(g:zd_tpl_daily, l:replacements)
@@ -160,6 +205,9 @@ function! s:OpenDailyNote(...) abort
       \ '---',
       \ '',
       \ '## ' . l:readable_date,
+      \ '',
+      \ '#### Projects by Area',
+      \ ] + l:proj_lines + [
       \ '',
       \ ]
     endif
@@ -732,4 +780,40 @@ function! s:OpenAreasIndex() abort
 endfunction
 
 nnoremap <silent> <leader>zA :call <SID>OpenAreasIndex()<CR>
+
+" =============================================================================
+"                   SUMMARIZE DAILY NOTES WITH LLAMA-CLI
+" =============================================================================
+
+" Gather the contents of the last {days} daily notes and feed them to
+" `llama-cli` for summarization.  Defaults to 1 day.
+function! s:SummarizeRecentDays(...) abort
+  let l:days = (a:0 > 0 ? a:1 : 1)
+  let l:all_lines = []
+  for i in range(l:days - 1, 0, -1)
+    let l:stamp = strftime('%y%m%d', localtime() - i * 86400)
+    let l:file = g:zd_dir_daily . '/' . l:stamp . '.md'
+    if filereadable(l:file)
+      call extend(l:all_lines, ['# ' . l:stamp] + readfile(l:file) + [''])
+    endif
+  endfor
+  if empty(l:all_lines)
+    echo 'No daily notes found.'
+    return
+  endif
+  let l:prompt = 'Summarize the following notes:\n' . join(l:all_lines, "\n")
+  let l:cmd = 'llama-cli -hf ' . g:zd_llama_repo . ' -p ' . shellescape(l:prompt)
+  let l:summary = system(l:cmd)
+  botright new
+  call setline(1, split(l:summary, "\n"))
+  setlocal buftype=nofile bufhidden=wipe noswapfile
+endfunction
+
+" Wrapper to summarize recent weeks (7 * n days)
+function! s:SummarizeRecentWeeks(...) abort
+  let l:weeks = (a:0 > 0 ? a:1 : 1)
+  call s:SummarizeRecentDays(l:weeks * 7)
+endfunction
+
+nnoremap <silent> <leader>zs :call <SID>SummarizeRecentDays()<CR>
 


### PR DESCRIPTION
## Summary
- add `g:zd_llama_repo` configuration for llama model
- implement `SummarizeRecentDays` and `SummarizeRecentWeeks` helpers
- map `<leader>zs` to summarize last day by default
- document llama summary support and mapping
- show projects grouped by area in daily template

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869a4893f748326a2d3e1a491b0c435