### PR TITLE
Add faster-whisper summary mode

### DIFF
--- a/faster_whisper.py
+++ b/faster_whisper.py
@@ -1,0 +1,29 @@
+import argparse
+from faster_whisper import WhisperModel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe audio using faster-whisper")
+    parser.add_argument("audio", help="Input audio file")
+    parser.add_argument("--model", default="large-v3", help="Model size or path")
+    parser.add_argument("--device", default="cuda", help="Device to use")
+    parser.add_argument("--output", required=True, help="Output text file")
+    parser.add_argument("--beam_size", type=int, default=10, help="Beam search size")
+    parser.add_argument("--language", default="en", help="Language code")
+    args = parser.parse_args()
+
+    model = WhisperModel(args.model, device=args.device, compute_type="float16")
+    segments, info = model.transcribe(
+        args.audio,
+        beam_size=args.beam_size,
+        language=args.language,
+        vad_filter=True,
+        condition_on_previous_text=False,
+    )
+    with open(args.output, "w", encoding="utf-8") as out:
+        for segment in segments:
+            out.write(segment.text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/vim-zk.vim
+++ b/vim-zk.vim
@@ -43,8 +43,10 @@ let g:zd_areas_index = g:zd_dir_areas . '/areas.md'
 
 " Llama model repo for summaries
 let g:zd_llama_repo = 'unsloth/gemma-3n-E4B-it-GGUF'
-" Whisper model (for speech-to-text)
+" faster-whisper model (for speech-to-text)
 let g:zd_whisper_model = 'large-v3'
+" Command used to run faster-whisper (can include python interpreter)
+let g:zd_whisper_cmd = 'faster-whisper'
 
 " Create top-level directories if they don't exist
 call mkdir(g:zd_dir_daily, 'p')
@@ -874,6 +876,31 @@ function! s:JobStart(cmd, opts) abort
   endif
 endfunction
 
+" Summarize an arbitrary text file using llama-cli
+function! s:SummarizeFile(file, summary_file) abort
+  if !filereadable(a:file)
+    echom 'File not found: ' . a:file
+    return
+  endif
+  let l:lines = readfile(a:file)
+  let l:prompt = 'Summarize the following text:\n' . join(l:lines, "\n")
+  let l:cmd = 'llama-cli -hf ' . g:zd_llama_repo . ' -p ' . shellescape(l:prompt)
+  call mkdir(fnamemodify(a:summary_file, ':h'), 'p')
+  echom 'Running llama-cli asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': a:summary_file, 'out': [] }
+    let l:opts = {
+          \ 'stdout_buffered': 1,
+          \ 'on_stdout': function('<SID>LlamaCollect', [l:ctx]),
+          \ 'on_stderr': function('<SID>LlamaCollect', [l:ctx]),
+          \ 'on_exit': function('<SID>LlamaFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    let l:summary = system(l:cmd)
+    call <SID>LlamaFinish({ 'file': a:summary_file, 'out': split(l:summary, "\n") }, 0, 0)
+  endif
+endfunction
+
 " Wrapper to summarize recent weeks (7 * n days)
 function! s:SummarizeRecentWeeks(...) abort
   let l:weeks = (a:0 > 0 ? a:1 : 1)
@@ -885,8 +912,33 @@ nnoremap <silent> <leader>zS5 :call <SID>SummarizeRecentDays(5)<CR>
 nnoremap <silent> <leader>zS2 :call <SID>SummarizeRecentDays(2)<CR>
 
 " =============================================================================
-"                     VOICE-TO-TEXT VIA WHISPER
+"                     VOICE-TO-TEXT VIA FASTER-WHISPER
 " =============================================================================
+
+function! s:_WhisperTranscribe(audio, summary) abort
+  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(a:audio, ':t:r') . '.txt'
+  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
+  let l:cmd = g:zd_whisper_cmd . ' ' . shellescape(a:audio) .
+        \ ' --model ' . g:zd_whisper_model .
+        \ ' --device cuda --output ' . shellescape(l:out_file)
+
+  echom 'Running faster-whisper asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': l:out_file, 'summary': a:summary }
+    if a:summary
+      let l:ctx.summary_file = g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt'
+    endif
+    let l:opts = {
+          \ 'stdout_buffered': 1,
+          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    echom 'jobstart() not available, running synchronously.'
+    call system(l:cmd)
+    call <SID>WhisperFinish({ 'file': l:out_file, 'summary': a:summary,
+          \ 'summary_file': (a:summary ? g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt' : '') }, 0, 0)
+  endif
+endfunction
 
 function! s:WhisperTranscribe(...) abort
   if a:0 > 0
@@ -898,31 +950,30 @@ function! s:WhisperTranscribe(...) abort
     echo 'No audio provided.'
     return
   endif
+  call s:_WhisperTranscribe(l:audio, 0)
+endfunction
 
-  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(l:audio, ':t:r') . '.txt'
-  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
-  let l:cmd = 'whisper ' . shellescape(l:audio) .
-        \ ' --model ' . g:zd_whisper_model .
-        \ ' --device cuda --output_format txt --output_dir ' . shellescape(g:zd_dir_transcripts)
-
-  echom 'Running whisper asynchronously...'
-  if exists('*jobstart') || exists('*job_start')
-    let l:ctx = { 'file': l:out_file }
-    let l:opts = {
-          \ 'stdout_buffered': 1,
-          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
-    call s:JobStart(l:cmd, l:opts)
+function! s:WhisperTranscribeAndSummarize(...) abort
+  if a:0 > 0
+    let l:audio = a:1
   else
-    echom 'jobstart() not available, running synchronously.'
-    call system(l:cmd)
-    call <SID>WhisperFinish({ 'file': l:out_file }, 0, 0)
+    let l:audio = input('Audio file: ')
   endif
+  if empty(l:audio)
+    echo 'No audio provided.'
+    return
+  endif
+  call s:_WhisperTranscribe(l:audio, 1)
 endfunction
 
 function! s:WhisperFinish(ctx, job, status) abort
   echom 'Transcription saved to ' . a:ctx.file
   execute 'edit ' . fnameescape(a:ctx.file)
+  if get(a:ctx, 'summary', 0)
+    call s:SummarizeFile(a:ctx.file, a:ctx.summary_file)
+  endif
 endfunction
 
 nnoremap <silent> <leader>zv :call <SID>WhisperTranscribe()<CR>
+nnoremap <silent> <leader>zV :call <SID>WhisperTranscribeAndSummarize()<CR>
 


### PR DESCRIPTION
## Summary
- allow configuring the path to the faster-whisper script via `g:zd_whisper_cmd`
- document the new setting and update setup instructions
- add `WhisperTranscribeAndSummarize` to transcribe audio then summarize it
- show how to run both transcription and summarization asynchronously

## Testing
- `echo 'no tests'`


------
https://chatgpt.com/codex/tasks/task_e_6869cb80058c832692cb12bd7a9cbfad