### PR TITLE
Fix async callbacks for whisper/recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
   - `:call <SID>SummarizeRecentWeeks(n)` summarizes `n` weeks (7×n days).
   - Runs asynchronously so you can keep editing while `llama-cli` works.
 - **Whisper Transcription**:
-  - Uses the `whisper` CLI with the `large-v3` model for wide vocabulary.
+  - Uses [faster-whisper](https://github.com/guillaumekln/faster-whisper) for speedy voice to text.
+  - Command configured via `g:zd_whisper_cmd` (defaults to `faster-whisper`).
   - CUDA accelerated and runs asynchronously similar to the summarizer.
   - Transcripts are saved under `~/.zd/transcripts/`.
-  - Trigger with `<leader>zv` or call `:call <SID>WhisperTranscribe('file.wav')`.
+  - Results open in split windows so you can keep editing while they load.
+  - Call `:call <SID>WhisperTranscribe('file.wav')` to convert existing audio.
+  - Press `<leader>zr` to **record** with `arecord` for `g:zd_record_seconds` seconds and transcribe.
+  - Press `<leader>zR` to record, transcribe, **and** summarize in one go.
 
 - **Templating System**:
   - Store your own markdown templates in `~/.zd/templates/` (e.g. `daily.md`, `weekly.md`, etc.).
@@ -63,7 +67,9 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
 1. **Prerequisites**:
    - You need a running Vim or Neovim environment.
    - This plugin is pure Vimscript; no external dependencies required.
-   - Install `llama-cli` if you want to use the summary feature.
+  - Install `llama-cli` if you want to use the summary feature.
+  - Install `arecord` (from ALSA) to capture audio snippets.
+  - Install the `whisper` CLI for compatibility with earlier versions.
 
 2. **Plugin File**:
    - Save the plugin script as `vim-zk.vim` in your local plugin directory:
@@ -84,6 +90,66 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
    If no template is found, fallback text is used.
 
 5. **Restart** Vim/Neovim and you’re ready!
+
+## Faster-Whisper Setup 🗣️
+
+The voice transcription feature now relies on the [faster-whisper](https://github.com/guillaumekln/faster-whisper) library.
+Set it up like this:
+
+1. Install **Python 3** and **ffmpeg** on your system.
+2. Install the package via pip:
+   ```bash
+   pip install -U faster-whisper
+   ```
+3. Create a helper script (see `faster_whisper.py` in this repo) and note its location:
+   ```python
+   #!/usr/bin/env python3
+   from faster_whisper import WhisperModel
+   import argparse
+
+   parser = argparse.ArgumentParser()
+   parser.add_argument("audio")
+   parser.add_argument("--model", default="large-v3")
+   parser.add_argument("--device", default="cuda")
+   parser.add_argument("--output", required=True)
+   args = parser.parse_args()
+
+   model = WhisperModel(args.model, device=args.device, compute_type="float16")
+   segments, _ = model.transcribe(
+       args.audio,
+       beam_size=10,
+       language="en",
+       vad_filter=True,
+       condition_on_previous_text=False,
+   )
+   with open(args.output, "w", encoding="utf-8") as f:
+       for seg in segments:
+           f.write(seg.text + "\n")
+   ```
+   Use it with a Python interpreter, e.g. `~/.venv/bin/python3.10 /path/to/faster_whisper.py`.
+4. Set `g:zd_whisper_cmd` in your `vimrc` to that command so the plugin can invoke it.
+   (If you installed `faster-whisper` system-wide, leave it as the default.)
+5. Optionally tweak the model by setting `g:zd_whisper_model` (defaults to `large-v3`).
+
+After setup, press `<leader>zr` to record and transcribe, or call
+`WhisperTranscribe('path/to/file.wav')` for existing audio. The transcript (and
+optional summary) will appear in dedicated split windows.
+
+## Whisper Setup (optional)
+
+To use the original `whisper` CLI instead of faster-whisper, install it with pip:
+
+```bash
+pip install git+https://github.com/openai/whisper.git
+```
+
+Ensure `whisper` is on your `PATH`, then set:
+
+```vim
+let g:zd_whisper_cmd = 'whisper'
+```
+
+The plugin will invoke it just like the faster-whisper script.
 
 ---
 
@@ -106,7 +172,8 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
 | `<leader>zp` | **Open/Prompt for Project**: Creates or opens a project’s `main_project.md`.                 |
 | `<leader>zP` | **Open Projects Index**: Opens the master `projects.md` listing all created projects.        |
 | `<leader>zs` | **Summarize Dailies**: Asynchronously run `llama-cli` on the last day (or use `:call <SID>SummarizeRecentDays(n)` for more) and store the result. |
-| `<leader>zv` | **Whisper Transcribe**: Convert an audio file to text using the CUDA-accelerated `whisper` CLI. |
+| `<leader>zr` | **Record & Transcribe**: Record via `arecord` then transcribe. |
+| `<leader>zR` | **Record, Transcribe & Summarize**: Capture audio and generate a summary. |
 
 
 ### Example Workflows
@@ -121,9 +188,8 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
    - Press `<leader>zp` → type “MyAwesomeProject.”
    - A new folder `~/.zd/projects/MyAwesomeProject/` is made, along with `main_project.md` from a template.
    - A link `[MyAwesomeProject](MyAwesomeProject/main_project.md)` is added to `projects.md`.
-4. **Transcribe a Voice Note**:
-   - Record an audio snippet, then press `<leader>zv` and enter the file path.
-   - The transcript opens in a new buffer once `whisper` finishes.
+4. **Record and Transcribe**:
+   - Press `<leader>zr` to capture audio for a few seconds and automatically open the transcript.
 
 ---
 
@@ -145,6 +211,8 @@ By default, the plugin organizes notes under `~/.zd/`:
   │   └─ <ProjectName>/main_project.md
   ├─ transcripts/
   │   └─ <audio>.txt
+  ├─ recordings/
+  │   └─ <timestamp>.wav
   └─ templates/
       ├─ daily.md
       ├─ weekly.md

--- a/faster_whisper.py
+++ b/faster_whisper.py
@@ -1,0 +1,29 @@
+import argparse
+from faster_whisper import WhisperModel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe audio using faster-whisper")
+    parser.add_argument("audio", help="Input audio file")
+    parser.add_argument("--model", default="large-v3", help="Model size or path")
+    parser.add_argument("--device", default="cuda", help="Device to use")
+    parser.add_argument("--output", required=True, help="Output text file")
+    parser.add_argument("--beam_size", type=int, default=10, help="Beam search size")
+    parser.add_argument("--language", default="en", help="Language code")
+    args = parser.parse_args()
+
+    model = WhisperModel(args.model, device=args.device, compute_type="float16")
+    segments, info = model.transcribe(
+        args.audio,
+        beam_size=args.beam_size,
+        language=args.language,
+        vad_filter=True,
+        condition_on_previous_text=False,
+    )
+    with open(args.output, "w", encoding="utf-8") as out:
+        for segment in segments:
+            out.write(segment.text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/vim-zk.vim
+++ b/vim-zk.vim
@@ -24,6 +24,7 @@ let g:zd_dir_resources = g:zd_dir . '/resources'  " <--- shared resources
 let g:zd_dir_archives= g:zd_dir . '/archives'  " <--- old projects, etc, things unused but should keep
 let g:zd_dir_summaries = g:zd_dir . '/summaries'
 let g:zd_dir_transcripts = g:zd_dir . '/transcripts'
+let g:zd_dir_recordings = g:zd_dir . '/recordings'
 
 " Template filenames
 let g:zd_tpl_daily   = g:zd_dir_templates . '/daily.md'
@@ -43,8 +44,12 @@ let g:zd_areas_index = g:zd_dir_areas . '/areas.md'
 
 " Llama model repo for summaries
 let g:zd_llama_repo = 'unsloth/gemma-3n-E4B-it-GGUF'
-" Whisper model (for speech-to-text)
+" faster-whisper model (for speech-to-text)
 let g:zd_whisper_model = 'large-v3'
+" Command used to run faster-whisper (can include python interpreter)
+let g:zd_whisper_cmd = 'faster-whisper'
+" Seconds to record audio when using arecord
+let g:zd_record_seconds = 10
 
 " Create top-level directories if they don't exist
 call mkdir(g:zd_dir_daily, 'p')
@@ -59,6 +64,7 @@ call mkdir(g:zd_dir_resources, 'p')
 call mkdir(g:zd_dir_archives, 'p')
 call mkdir(g:zd_dir_summaries, 'p')
 call mkdir(g:zd_dir_transcripts, 'p')
+call mkdir(g:zd_dir_recordings, 'p')
 
 
 " =============================================================================
@@ -843,7 +849,7 @@ function! s:SummarizeRecentDays(...) abort
   else
     echom 'jobstart() not available, running synchronously.'
     let l:summary = system(l:cmd)
-    call <SID>LlamaFinish({ 'file': l:summary_file, 'out': split(l:summary, "\n") }, 0, 0)
+    call <SID>LlamaFinish({ 'file': l:summary_file, 'out': split(l:summary, "\n") }, 0, 0, '')
   endif
 endfunction
 
@@ -853,7 +859,10 @@ function! s:LlamaCollect(ctx, job, data, event) abort
   endif
 endfunction
 
-function! s:LlamaFinish(ctx, job, status) abort
+" Finish callback for llama-cli job. Accept an unused event parameter for
+" compatibility with different Vim/Neovim versions which may pass three values
+" to on_exit.
+function! s:LlamaFinish(ctx, job, status, ...) abort
   if a:ctx.out[-1] ==# ''
     call remove(a:ctx.out, -1)
   endif
@@ -874,6 +883,31 @@ function! s:JobStart(cmd, opts) abort
   endif
 endfunction
 
+" Summarize an arbitrary text file using llama-cli
+function! s:SummarizeFile(file, summary_file) abort
+  if !filereadable(a:file)
+    echom 'File not found: ' . a:file
+    return
+  endif
+  let l:lines = readfile(a:file)
+  let l:prompt = 'Summarize the following text:\n' . join(l:lines, "\n")
+  let l:cmd = 'llama-cli -hf ' . g:zd_llama_repo . ' -p ' . shellescape(l:prompt)
+  call mkdir(fnamemodify(a:summary_file, ':h'), 'p')
+  echom 'Running llama-cli asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': a:summary_file, 'out': [] }
+    let l:opts = {
+          \ 'stdout_buffered': 1,
+          \ 'on_stdout': function('<SID>LlamaCollect', [l:ctx]),
+          \ 'on_stderr': function('<SID>LlamaCollect', [l:ctx]),
+          \ 'on_exit': function('<SID>LlamaFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    let l:summary = system(l:cmd)
+    call <SID>LlamaFinish({ 'file': a:summary_file, 'out': split(l:summary, "\n") }, 0, 0, '')
+  endif
+endfunction
+
 " Wrapper to summarize recent weeks (7 * n days)
 function! s:SummarizeRecentWeeks(...) abort
   let l:weeks = (a:0 > 0 ? a:1 : 1)
@@ -885,8 +919,33 @@ nnoremap <silent> <leader>zS5 :call <SID>SummarizeRecentDays(5)<CR>
 nnoremap <silent> <leader>zS2 :call <SID>SummarizeRecentDays(2)<CR>
 
 " =============================================================================
-"                     VOICE-TO-TEXT VIA WHISPER
+"                     VOICE-TO-TEXT VIA FASTER-WHISPER
 " =============================================================================
+
+function! s:_WhisperTranscribe(audio, summary) abort
+  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(a:audio, ':t:r') . '.txt'
+  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
+  let l:cmd = g:zd_whisper_cmd . ' ' . shellescape(a:audio) .
+        \ ' --model ' . g:zd_whisper_model .
+        \ ' --device cuda --output ' . shellescape(l:out_file)
+
+  echom 'Running faster-whisper asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': l:out_file, 'summary': a:summary }
+    if a:summary
+      let l:ctx.summary_file = g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt'
+    endif
+    let l:opts = {
+          \ 'stdout_buffered': 1,
+          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    echom 'jobstart() not available, running synchronously.'
+    call system(l:cmd)
+    call <SID>WhisperFinish({ 'file': l:out_file, 'summary': a:summary,
+          \ 'summary_file': (a:summary ? g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt' : '') }, 0, 0, '')
+  endif
+endfunction
 
 function! s:WhisperTranscribe(...) abort
   if a:0 > 0
@@ -898,31 +957,73 @@ function! s:WhisperTranscribe(...) abort
     echo 'No audio provided.'
     return
   endif
+  call s:_WhisperTranscribe(l:audio, 0)
+endfunction
 
-  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(l:audio, ':t:r') . '.txt'
-  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
-  let l:cmd = 'whisper ' . shellescape(l:audio) .
-        \ ' --model ' . g:zd_whisper_model .
-        \ ' --device cuda --output_format txt --output_dir ' . shellescape(g:zd_dir_transcripts)
-
-  echom 'Running whisper asynchronously...'
-  if exists('*jobstart') || exists('*job_start')
-    let l:ctx = { 'file': l:out_file }
-    let l:opts = {
-          \ 'stdout_buffered': 1,
-          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
-    call s:JobStart(l:cmd, l:opts)
+function! s:WhisperTranscribeAndSummarize(...) abort
+  if a:0 > 0
+    let l:audio = a:1
   else
-    echom 'jobstart() not available, running synchronously.'
-    call system(l:cmd)
-    call <SID>WhisperFinish({ 'file': l:out_file }, 0, 0)
+    let l:audio = input('Audio file: ')
+  endif
+  if empty(l:audio)
+    echo 'No audio provided.'
+    return
+  endif
+  call s:_WhisperTranscribe(l:audio, 1)
+endfunction
+
+" Callback after faster-whisper completes. Accept an optional event argument
+" because Neovim passes three parameters (job, status, event) to on_exit.
+" Reformat a text file to 80 columns using `fold -s` if available
+function! s:WrapFile80(file) abort
+  if filereadable(a:file) && executable('fold')
+    let l:tmp = tempname()
+    call system('fold -s -w 80 ' . shellescape(a:file) . ' > ' . shellescape(l:tmp))
+    call rename(l:tmp, a:file)
   endif
 endfunction
 
-function! s:WhisperFinish(ctx, job, status) abort
+function! s:WhisperFinish(ctx, job, status, ...) abort
+  call s:WrapFile80(a:ctx.file)
   echom 'Transcription saved to ' . a:ctx.file
-  execute 'edit ' . fnameescape(a:ctx.file)
+  execute 'botright vsplit ' . fnameescape(a:ctx.file)
+  if get(a:ctx, 'summary', 0)
+    call s:SummarizeFile(a:ctx.file, a:ctx.summary_file)
+  endif
 endfunction
 
-nnoremap <silent> <leader>zv :call <SID>WhisperTranscribe()<CR>
+" Record audio using arecord and then transcribe
+function! s:_WhisperRecord(summary) abort
+  let l:audio = g:zd_dir_recordings . '/' . strftime('%Y%m%d-%H%M%S') . '.wav'
+  call mkdir(fnamemodify(l:audio, ':h'), 'p')
+  let l:cmd = 'arecord -f cd -d ' . g:zd_record_seconds . ' ' . shellescape(l:audio)
+  echom 'Recording ' . g:zd_record_seconds . ' seconds of audio...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'audio': l:audio, 'summary': a:summary }
+    let l:opts = { 'on_exit': function('<SID>RecordFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    call system(l:cmd)
+    call <SID>RecordFinish({ 'audio': l:audio, 'summary': a:summary }, 0, 0, '')
+  endif
+endfunction
+
+" Called after arecord finishes to kick off transcription. Accept a dummy event
+" argument for compatibility with Neovim's on_exit callback.
+function! s:RecordFinish(ctx, job, status, ...) abort
+  echom 'Recording saved to ' . a:ctx.audio
+  call s:_WhisperTranscribe(a:ctx.audio, a:ctx.summary)
+endfunction
+
+function! s:WhisperRecordTranscribe() abort
+  call s:_WhisperRecord(0)
+endfunction
+
+function! s:WhisperRecordTranscribeAndSummarize() abort
+  call s:_WhisperRecord(1)
+endfunction
+
+nnoremap <silent> <leader>zr :call <SID>WhisperRecordTranscribe()<CR>
+nnoremap <silent> <leader>zR :call <SID>WhisperRecordTranscribeAndSummarize()<CR>
 


### PR DESCRIPTION
## Summary
- tweak README for faster-whisper setup and hotkeys
- ensure llama-cli and whisper callbacks accept optional `event` argument
- add missing argument in synchronous paths
- show transcripts in split window
- remove zv/zV mappings and wrap transcripts to 80 columns

## Testing
- `echo 'no tests'`


------
https://chatgpt.com/codex/tasks/task_e_6869cb80058c832692cb12bd7a9cbfad