### PR TITLE
Switch summaries to Ollama script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,26 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
   - Automatically added to `~/.zd/projects/projects.md` (a master index).
   - Quickly open any project from an interactive prompt.
   - Daily notes show all projects grouped by area for quick access.
-- **Llama Summaries**:
-  - Use `llama-cli` to generate a summary of recent daily notes.
-  - Set `g:zd_llama_repo` to select the model repository.
+- **Ollama Summaries**:
+  - Use a Python helper (`summarize_markdown.py`) to generate summaries via [Ollama](https://ollama.com/).
+  - Configure the script path with `g:zd_ollama_cmd` and the model with `g:zd_ollama_model`.
   - Summaries are saved under `~/.zd/summaries/<start>_<end>.txt` (customize via `g:zd_dir_summaries`).
   - Trigger with `<leader>zs` for the last day or call `:call <SID>SummarizeRecentDays(n)` for `n` days.
   - `:call <SID>SummarizeRecentWeeks(n)` summarizes `n` weeks (7×n days).
-  - Runs asynchronously so you can keep editing while `llama-cli` works.
+  - Runs asynchronously so you can keep editing while Ollama works.
 - **Whisper Transcription**:
-  - Uses the `whisper` CLI with the `large-v3` model for wide vocabulary.
+  - Uses [faster-whisper](https://github.com/guillaumekln/faster-whisper) for speedy voice to text.
+  - Command configured via `g:zd_whisper_cmd` (defaults to `faster-whisper`).
   - CUDA accelerated and runs asynchronously similar to the summarizer.
   - Transcripts are saved under `~/.zd/transcripts/`.
-  - Trigger with `<leader>zv` or call `:call <SID>WhisperTranscribe('file.wav')`.
+  - Results open in split windows so you can keep editing while they load.
+  - Call `:call <SID>WhisperTranscribe('file.wav')` to convert existing audio.
+  - Press `<leader>zr` to **record** with `arecord` for `g:zd_record_seconds` seconds and transcribe.
+  - Press `<leader>zR` to record, transcribe, **and summarize** the audio.
+  - Summary buffers show the transcript text followed by the LLM's summary.
+  - **File Summaries**:
+    - `<leader>zB` summarizes the current file into a bullet list using Ollama.
+    - `<leader>zM` summarizes the current file as structured Markdown with headings.
 
 - **Templating System**:
   - Store your own markdown templates in `~/.zd/templates/` (e.g. `daily.md`, `weekly.md`, etc.).
@@ -63,7 +71,9 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
 1. **Prerequisites**:
    - You need a running Vim or Neovim environment.
    - This plugin is pure Vimscript; no external dependencies required.
-   - Install `llama-cli` if you want to use the summary feature.
+  - Install the `ollama` Python package and place `summarize_markdown.py` on your `PATH` (or set `g:zd_ollama_cmd`).
+  - Install `arecord` (from ALSA) to capture audio snippets.
+  - Install the `whisper` CLI for compatibility with earlier versions.
 
 2. **Plugin File**:
    - Save the plugin script as `vim-zk.vim` in your local plugin directory:
@@ -85,6 +95,77 @@ All integrated into Vim/Neovim via handy shortcuts and a few dynamic templates.
 
 5. **Restart** Vim/Neovim and you’re ready!
 
+## Ollama Setup ✍️
+
+File summaries rely on a small Python script that uses [Ollama](https://ollama.com/).
+1. Install the `ollama` Python package:
+   ```bash
+   pip install ollama
+   ```
+2. Copy `summarize_markdown.py` from this repo somewhere on your `PATH` (or set
+   `g:zd_ollama_cmd` to its full path).
+3. Optionally pick a different model by setting `g:zd_ollama_model`.
+
+## Faster-Whisper Setup 🗣️
+
+The voice transcription feature now relies on the [faster-whisper](https://github.com/guillaumekln/faster-whisper) library.
+Set it up like this:
+
+1. Install **Python 3** and **ffmpeg** on your system.
+2. Install the package via pip:
+   ```bash
+   pip install -U faster-whisper
+   ```
+3. Create a helper script (see `faster_whisper.py` in this repo) and note its location:
+   ```python
+   #!/usr/bin/env python3
+   from faster_whisper import WhisperModel
+   import argparse
+
+   parser = argparse.ArgumentParser()
+   parser.add_argument("audio")
+   parser.add_argument("--model", default="large-v3")
+   parser.add_argument("--device", default="cuda")
+   parser.add_argument("--output", required=True)
+   args = parser.parse_args()
+
+   model = WhisperModel(args.model, device=args.device, compute_type="float16")
+   segments, _ = model.transcribe(
+       args.audio,
+       beam_size=10,
+       language="en",
+       vad_filter=True,
+       condition_on_previous_text=False,
+   )
+   with open(args.output, "w", encoding="utf-8") as f:
+       for seg in segments:
+           f.write(seg.text + "\n")
+   ```
+   Use it with a Python interpreter, e.g. `~/.venv/bin/python3.10 /path/to/faster_whisper.py`.
+4. Set `g:zd_whisper_cmd` in your `vimrc` to that command so the plugin can invoke it.
+   (If you installed `faster-whisper` system-wide, leave it as the default.)
+5. Optionally tweak the model by setting `g:zd_whisper_model` (defaults to `large-v3`).
+
+After setup, press `<leader>zr` to record and transcribe, or call
+`WhisperTranscribe('path/to/file.wav')` for existing audio. The transcript (and
+optional summary) will appear in dedicated split windows.
+
+## Whisper Setup (optional)
+
+To use the original `whisper` CLI instead of faster-whisper, install it with pip:
+
+```bash
+pip install git+https://github.com/openai/whisper.git
+```
+
+Ensure `whisper` is on your `PATH`, then set:
+
+```vim
+let g:zd_whisper_cmd = 'whisper'
+```
+
+The plugin will invoke it just like the faster-whisper script.
+
 ---
 
 ## Usage & Shortcuts ⌨️
@@ -105,8 +186,11 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
 | `<leader>tO` | **Open Done TODOS**: Quickly open `~/.zd/todos/done_todos.md`.                               |
 | `<leader>zp` | **Open/Prompt for Project**: Creates or opens a project’s `main_project.md`.                 |
 | `<leader>zP` | **Open Projects Index**: Opens the master `projects.md` listing all created projects.        |
-| `<leader>zs` | **Summarize Dailies**: Asynchronously run `llama-cli` on the last day (or use `:call <SID>SummarizeRecentDays(n)` for more) and store the result. |
-| `<leader>zv` | **Whisper Transcribe**: Convert an audio file to text using the CUDA-accelerated `whisper` CLI. |
+| `<leader>zs` | **Summarize Dailies**: Asynchronously run the Ollama summarizer on the last day (or use `:call <SID>SummarizeRecentDays(n)` for more) and store the result. |
+| `<leader>zr` | **Record & Transcribe**: Record via `arecord` then transcribe. |
+| `<leader>zR` | **Record, Transcribe & Summarize**: Capture audio and generate a summary. |
+| `<leader>zB` | **Summarize File (Bullets)**: Generate a bullet list summary of the current file. |
+| `<leader>zM` | **Summarize File (Markdown)**: Summarize the current file with Markdown headings. |
 
 
 ### Example Workflows
@@ -121,9 +205,10 @@ Below are the default mappings (`<leader>` often defaults to `\` in Vim, but you
    - Press `<leader>zp` → type “MyAwesomeProject.”
    - A new folder `~/.zd/projects/MyAwesomeProject/` is made, along with `main_project.md` from a template.
    - A link `[MyAwesomeProject](MyAwesomeProject/main_project.md)` is added to `projects.md`.
-4. **Transcribe a Voice Note**:
-   - Record an audio snippet, then press `<leader>zv` and enter the file path.
-   - The transcript opens in a new buffer once `whisper` finishes.
+4. **Record and Transcribe**:
+   - Press `<leader>zr` to capture audio for a few seconds and automatically open the transcript.
+5. **Record, Transcribe & Summarize**:
+   - Press `<leader>zR` to capture audio and view both the transcript and its summary.
 
 ---
 
@@ -145,6 +230,8 @@ By default, the plugin organizes notes under `~/.zd/`:
   │   └─ <ProjectName>/main_project.md
   ├─ transcripts/
   │   └─ <audio>.txt
+  ├─ recordings/
+  │   └─ <timestamp>.wav
   └─ templates/
       ├─ daily.md
       ├─ weekly.md

--- a/faster_whisper.py
+++ b/faster_whisper.py
@@ -1,0 +1,29 @@
+import argparse
+from faster_whisper import WhisperModel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe audio using faster-whisper")
+    parser.add_argument("audio", help="Input audio file")
+    parser.add_argument("--model", default="large-v3", help="Model size or path")
+    parser.add_argument("--device", default="cuda", help="Device to use")
+    parser.add_argument("--output", required=True, help="Output text file")
+    parser.add_argument("--beam_size", type=int, default=10, help="Beam search size")
+    parser.add_argument("--language", default="en", help="Language code")
+    args = parser.parse_args()
+
+    model = WhisperModel(args.model, device=args.device, compute_type="float16")
+    segments, info = model.transcribe(
+        args.audio,
+        beam_size=args.beam_size,
+        language=args.language,
+        vad_filter=True,
+        condition_on_previous_text=False,
+    )
+    with open(args.output, "w", encoding="utf-8") as out:
+        for segment in segments:
+            out.write(segment.text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/summarize_markdown.py
+++ b/summarize_markdown.py
@@ -1,0 +1,56 @@
+import argparse
+import ollama
+from pathlib import Path
+import sys
+import datetime
+
+
+def summarize_file(input_path: Path, model: str, output_path: Path, prompt: str) -> None:
+    try:
+        text = input_path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"Error reading input file: {e}")
+        sys.exit(1)
+
+    if not prompt:
+        prompt = (
+            "Please summarize the following content in **markdown format**, "
+            "with bullet points, bold section headers, and concise phrasing:\n\n"
+        )
+    prompt = f"{prompt}\n{text}"
+
+    print(f"Summarizing with model [{model}]...")
+    try:
+        response = ollama.chat(model=model, messages=[{"role": "user", "content": prompt}])
+    except Exception as e:
+        print(f"Error during summarization: {e}")
+        sys.exit(1)
+
+    summary = response.get("message", {}).get("content", "")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(summary, encoding="utf-8")
+        print(f"✅ Summary saved to: {output_path}")
+    except Exception as e:
+        print(f"Error writing summary: {e}")
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Summarize a file using Ollama")
+    parser.add_argument("input", type=Path, help="Path to the input text file")
+    parser.add_argument("--model", default="hf.co/unsloth/gemma-3n-E4B-it-GGUF:Q4_K_XL", help="Ollama model name")
+    parser.add_argument("--output", type=Path, required=True, help="Path to save the summary")
+    parser.add_argument("--prompt", default="", help="Optional custom prompt")
+    args = parser.parse_args()
+
+    if args.output is None:
+        ts = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        out_name = args.input.stem + f"_summary_{ts}.md"
+        args.output = Path.home() / ".zd" / "summaries" / out_name
+
+    summarize_file(args.input, args.model, args.output, args.prompt)
+
+
+if __name__ == "__main__":
+    main()

--- a/vim-zk.vim
+++ b/vim-zk.vim
@@ -24,6 +24,7 @@ let g:zd_dir_resources = g:zd_dir . '/resources'  " <--- shared resources
 let g:zd_dir_archives= g:zd_dir . '/archives'  " <--- old projects, etc, things unused but should keep
 let g:zd_dir_summaries = g:zd_dir . '/summaries'
 let g:zd_dir_transcripts = g:zd_dir . '/transcripts'
+let g:zd_dir_recordings = g:zd_dir . '/recordings'
 
 " Template filenames
 let g:zd_tpl_daily   = g:zd_dir_templates . '/daily.md'
@@ -41,10 +42,16 @@ let g:zd_done_todos   = g:zd_dir_todos . '/done_todos.md'
 let g:zd_projects_index = g:zd_dir_projects . '/projects.md'
 let g:zd_areas_index = g:zd_dir_areas . '/areas.md'
 
-" Llama model repo for summaries
-let g:zd_llama_repo = 'unsloth/gemma-3n-E4B-it-GGUF'
-" Whisper model (for speech-to-text)
+" Command used to run the Ollama-based summarizer script
+let g:zd_ollama_cmd = 'summarize_markdown.py'
+" Default model for Ollama summaries
+let g:zd_ollama_model = 'hf.co/unsloth/gemma-3n-E4B-it-GGUF:Q4_K_XL'
+" faster-whisper model (for speech-to-text)
 let g:zd_whisper_model = 'large-v3'
+" Command used to run faster-whisper (can include python interpreter)
+let g:zd_whisper_cmd = 'faster-whisper'
+" Seconds to record audio when using arecord
+let g:zd_record_seconds = 10
 
 " Create top-level directories if they don't exist
 call mkdir(g:zd_dir_daily, 'p')
@@ -59,6 +66,7 @@ call mkdir(g:zd_dir_resources, 'p')
 call mkdir(g:zd_dir_archives, 'p')
 call mkdir(g:zd_dir_summaries, 'p')
 call mkdir(g:zd_dir_transcripts, 'p')
+call mkdir(g:zd_dir_recordings, 'p')
 
 
 " =============================================================================
@@ -827,40 +835,34 @@ function! s:SummarizeRecentDays(...) abort
     echo 'No daily notes found.'
     return
   endif
-  let l:prompt = 'Summarize the following notes:\n' . join(l:all_lines, "\n")
-  let l:cmd = 'llama-cli -hf ' . g:zd_llama_repo . ' -p ' . shellescape(l:prompt)
+  let l:tmp = tempname()
+  call writefile(l:all_lines, l:tmp)
   let l:summary_file = g:zd_dir_summaries . '/' . l:start_stamp . '_' . l:end_stamp . '.txt'
-  call mkdir(fnamemodify(l:summary_file, ':h'), 'p')
-  echom 'Running llama-cli asynchronously...'
-  if exists('*jobstart') || exists('*job_start')
-    let l:ctx = { 'file': l:summary_file, 'out': [] }
-    let l:opts = {
-          \ 'stdout_buffered': 1,
-          \ 'on_stdout': function('<SID>LlamaCollect', [l:ctx]),
-          \ 'on_stderr': function('<SID>LlamaCollect', [l:ctx]),
-          \ 'on_exit': function('<SID>LlamaFinish', [l:ctx]) }
-    call s:JobStart(l:cmd, l:opts)
+  call s:SummarizeFile(l:tmp, l:summary_file, 'Summarize the following notes:', 0)
+  call delete(l:tmp)
+endfunction
+
+
+" Finish callback for Ollama summarizer job. Accept an unused event parameter
+" for compatibility with different Vim/Neovim versions which may pass three
+" values to on_exit.
+function! s:SummaryFinish(ctx, job, status, ...) abort
+  if filereadable(a:ctx.file)
+    call s:WrapFile80(a:ctx.file)
+    let l:summary = readfile(a:ctx.file)
   else
-    echom 'jobstart() not available, running synchronously.'
-    let l:summary = system(l:cmd)
-    call <SID>LlamaFinish({ 'file': l:summary_file, 'out': split(l:summary, "\n") }, 0, 0)
+    echom 'Summary file not found: ' . a:ctx.file
+    return
   endif
-endfunction
-
-function! s:LlamaCollect(ctx, job, data, event) abort
-  if a:event ==# 'stdout' || a:event ==# 'stderr'
-    call extend(a:ctx.out, a:data)
+  if get(a:ctx, 'show_source', 0) && filereadable(a:ctx.source)
+    let l:content = ['Prompt:'] + readfile(a:ctx.source) + ['', 'Summary:'] + l:summary
+    call writefile(l:content, a:ctx.file)
+  else
+    let l:content = l:summary
   endif
-endfunction
-
-function! s:LlamaFinish(ctx, job, status) abort
-  if a:ctx.out[-1] ==# ''
-    call remove(a:ctx.out, -1)
-  endif
-  call writefile(a:ctx.out, a:ctx.file)
   echom 'Summary saved to ' . a:ctx.file
   botright new
-  call setline(1, a:ctx.out)
+  call setline(1, l:content)
   setlocal buftype=nofile bufhidden=wipe noswapfile
 endfunction
 
@@ -871,6 +873,41 @@ function! s:JobStart(cmd, opts) abort
     return job_start(a:cmd, a:opts)
   else
     return -1
+  endif
+endfunction
+
+function! s:JobStop(job) abort
+  if exists('*jobstop')
+    call jobstop(a:job)
+  elseif exists('*job_stop')
+    call job_stop(a:job)
+  endif
+endfunction
+
+" Summarize an arbitrary text file using an Ollama-based script
+function! s:SummarizeFile(file, summary_file, ...) abort
+  if !filereadable(a:file)
+    echom 'File not found: ' . a:file
+    return
+  endif
+  let l:prompt = (a:0 > 0 ? a:1 : '')
+  let l:show = (a:0 > 1 ? a:2 : 1)
+  let l:cmd = g:zd_ollama_cmd . ' ' . shellescape(a:file) .
+        \ ' --output ' . shellescape(a:summary_file) .
+        \ ' --model ' . shellescape(g:zd_ollama_model)
+  if !empty(l:prompt)
+    let l:cmd .= ' --prompt ' . shellescape(l:prompt)
+  endif
+  call mkdir(fnamemodify(a:summary_file, ':h'), 'p')
+  echom 'Running Ollama summarizer asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': a:summary_file, 'show_source': l:show, 'source': a:file }
+    let l:opts = { 'on_exit': function('<SID>SummaryFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    echom 'jobstart() not available, running synchronously.'
+    call system(l:cmd)
+    call <SID>SummaryFinish({ 'file': a:summary_file, 'show_source': l:show, 'source': a:file }, 0, 0, '')
   endif
 endfunction
 
@@ -885,8 +922,33 @@ nnoremap <silent> <leader>zS5 :call <SID>SummarizeRecentDays(5)<CR>
 nnoremap <silent> <leader>zS2 :call <SID>SummarizeRecentDays(2)<CR>
 
 " =============================================================================
-"                     VOICE-TO-TEXT VIA WHISPER
+"                     VOICE-TO-TEXT VIA FASTER-WHISPER
 " =============================================================================
+
+function! s:_WhisperTranscribe(audio, summary) abort
+  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(a:audio, ':t:r') . '.txt'
+  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
+  let l:cmd = g:zd_whisper_cmd . ' ' . shellescape(a:audio) .
+        \ ' --model ' . g:zd_whisper_model .
+        \ ' --device cuda --output ' . shellescape(l:out_file)
+
+  echom 'Running faster-whisper asynchronously...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'file': l:out_file, 'summary': a:summary }
+    if a:summary
+      let l:ctx.summary_file = g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt'
+    endif
+    let l:opts = {
+          \ 'stdout_buffered': 1,
+          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    echom 'jobstart() not available, running synchronously.'
+    call system(l:cmd)
+    call <SID>WhisperFinish({ 'file': l:out_file, 'summary': a:summary,
+          \ 'summary_file': (a:summary ? g:zd_dir_summaries . '/' . fnamemodify(a:audio, ':t:r') . '_summary.txt' : '') }, 0, 0, '')
+  endif
+endfunction
 
 function! s:WhisperTranscribe(...) abort
   if a:0 > 0
@@ -898,31 +960,98 @@ function! s:WhisperTranscribe(...) abort
     echo 'No audio provided.'
     return
   endif
+  call s:_WhisperTranscribe(l:audio, 0)
+endfunction
 
-  let l:out_file = g:zd_dir_transcripts . '/' . fnamemodify(l:audio, ':t:r') . '.txt'
-  call mkdir(fnamemodify(l:out_file, ':h'), 'p')
-  let l:cmd = 'whisper ' . shellescape(l:audio) .
-        \ ' --model ' . g:zd_whisper_model .
-        \ ' --device cuda --output_format txt --output_dir ' . shellescape(g:zd_dir_transcripts)
-
-  echom 'Running whisper asynchronously...'
-  if exists('*jobstart') || exists('*job_start')
-    let l:ctx = { 'file': l:out_file }
-    let l:opts = {
-          \ 'stdout_buffered': 1,
-          \ 'on_exit': function('<SID>WhisperFinish', [l:ctx]) }
-    call s:JobStart(l:cmd, l:opts)
+function! s:WhisperTranscribeAndSummarize(...) abort
+  if a:0 > 0
+    let l:audio = a:1
   else
-    echom 'jobstart() not available, running synchronously.'
-    call system(l:cmd)
-    call <SID>WhisperFinish({ 'file': l:out_file }, 0, 0)
+    let l:audio = input('Audio file: ')
+  endif
+  if empty(l:audio)
+    echo 'No audio provided.'
+    return
+  endif
+  call s:_WhisperTranscribe(l:audio, 1)
+endfunction
+
+" Callback after faster-whisper completes. Accept an optional event argument
+" because Neovim passes three parameters (job, status, event) to on_exit.
+" Reformat a text file to 80 columns using `fold -s` if available
+function! s:WrapFile80(file) abort
+  if filereadable(a:file) && executable('fold')
+    let l:tmp = tempname()
+    call system('fold -s -w 80 ' . shellescape(a:file) . ' > ' . shellescape(l:tmp))
+    call rename(l:tmp, a:file)
   endif
 endfunction
 
-function! s:WhisperFinish(ctx, job, status) abort
+function! s:WhisperFinish(ctx, job, status, ...) abort
+  call s:WrapFile80(a:ctx.file)
   echom 'Transcription saved to ' . a:ctx.file
-  execute 'edit ' . fnameescape(a:ctx.file)
+  execute 'botright vsplit ' . fnameescape(a:ctx.file)
+  if get(a:ctx, 'summary', 0)
+    call s:SummarizeFile(a:ctx.file, a:ctx.summary_file)
+  endif
 endfunction
 
-nnoremap <silent> <leader>zv :call <SID>WhisperTranscribe()<CR>
+" Record audio using arecord and then transcribe
+function! s:_WhisperRecord(...) abort
+  let l:summary = (a:0 > 0 ? a:1 : 0)
+  let l:audio = g:zd_dir_recordings . '/' . strftime('%Y%m%d-%H%M%S') . '.wav'
+  call mkdir(fnamemodify(l:audio, ':h'), 'p')
+  let l:cmd = 'arecord -f cd -d ' . g:zd_record_seconds . ' ' . shellescape(l:audio)
+  echom 'Recording ' . g:zd_record_seconds . ' seconds of audio...'
+  if exists('*jobstart') || exists('*job_start')
+    let l:ctx = { 'audio': l:audio, 'summary': l:summary }
+    let l:opts = { 'on_exit': function('<SID>RecordFinish', [l:ctx]) }
+    call s:JobStart(l:cmd, l:opts)
+  else
+    call system(l:cmd)
+    call <SID>RecordFinish({ 'audio': l:audio, 'summary': l:summary }, 0, 0, '')
+  endif
+endfunction
 
+" Called after arecord finishes to kick off transcription. Accept a dummy event
+" argument for compatibility with Neovim's on_exit callback.
+function! s:RecordFinish(ctx, job, status, ...) abort
+  echom 'Recording saved to ' . a:ctx.audio
+  call s:_WhisperTranscribe(a:ctx.audio, get(a:ctx, 'summary', 0))
+endfunction
+
+function! s:WhisperRecordTranscribe() abort
+  call s:_WhisperRecord(0)
+endfunction
+
+function! s:WhisperRecordTranscribeAndSummarize() abort
+  call s:_WhisperRecord(1)
+endfunction
+
+nnoremap <silent> <leader>zr :call <SID>WhisperRecordTranscribe()<CR>
+nnoremap <silent> <leader>zR :call <SID>WhisperRecordTranscribeAndSummarize()<CR>
+
+" Summarize the current file as bullet points
+function! s:SummarizeCurrentBullet() abort
+  let l:file = expand('%:p')
+  if empty(l:file) || !filereadable(l:file)
+    echo 'No file to summarize.'
+    return
+  endif
+  let l:out = g:zd_dir_summaries . '/' . fnamemodify(l:file, ':t:r') . '_bullet.txt'
+  call s:SummarizeFile(l:file, l:out, 'Summarize the following text as bullet points:', 0)
+endfunction
+
+" Summarize the current file in markdown format
+function! s:SummarizeCurrentMarkdown() abort
+  let l:file = expand('%:p')
+  if empty(l:file) || !filereadable(l:file)
+    echo 'No file to summarize.'
+    return
+  endif
+  let l:out = g:zd_dir_summaries . '/' . fnamemodify(l:file, ':t:r') . '_summary.md'
+  call s:SummarizeFile(l:file, l:out, 'Summarize the following text in markdown with section headings and bullet points:', 0)
+endfunction
+
+nnoremap <silent> <leader>zB :call <SID>SummarizeCurrentBullet()<CR>
+nnoremap <silent> <leader>zM :call <SID>SummarizeCurrentMarkdown()<CR>


### PR DESCRIPTION
## Summary
- switch summarization from `llama-cli` to a Python script using Ollama
- add `summarize_markdown.py` helper
- add `g:zd_ollama_cmd` and `g:zd_ollama_model` options
- update documentation for new Ollama setup

## Testing
- `echo 'no tests'`


------
https://chatgpt.com/codex/tasks/task_e_6869cb80058c832692cb12bd7a9cbfad